### PR TITLE
feat(CBP-46171): plumb EDGE_REDACTION_STRIP_BASEDATA through chain actions

### DIFF
--- a/end-chain/action.yml
+++ b/end-chain/action.yml
@@ -3,6 +3,11 @@ kind: action
 name: scan
 description: "End scan chain"
 
+inputs:
+  edge-redaction-strip-basedata:
+    description: "When 'true', strip BaseData (raw source) from code-scanner findings before posting. Set by the workflow from start-chain's output on edge-routed scans; empty on cloud scans."
+    default: ""
+
 runs:
   using: composite
   steps:
@@ -16,3 +21,7 @@ runs:
         INPUT_CLOUDBEES_API_TOKEN: ${{ cloudbees.api.token }}
         INPUT_CLOUDBEES_API_URL: ${{ cloudbees.api.url }}
         INPUT_RUN_ID: ${{ cloudbees.run_id }}
+        # Edge redaction (CBP-46171). Read directly via os.Getenv in process-outputs;
+        # empty on cloud scans (no redaction). Passed in by the workflow from
+        # start-chain's output.
+        EDGE_REDACTION_STRIP_BASEDATA: ${{ inputs.edge-redaction-strip-basedata }}

--- a/start-chain/action.yml
+++ b/start-chain/action.yml
@@ -149,6 +149,10 @@ outputs:
     value: ${{ steps.plan.outputs.grype}}
     description: "Grype"
 
+  EDGE_REDACTION_STRIP_BASEDATA:
+    value: ${{ steps.plan.outputs.EDGE_REDACTION_STRIP_BASEDATA }}
+    description: "Strip BaseData (raw source) from code-scanner findings on edge"
+
 runs:
   using: composite
   steps:


### PR DESCRIPTION
[CBP-46171](https://cloudbees.atlassian.net/browse/CBP-46171)

## What

Action-manifest plumbing so the `EDGE_REDACTION_STRIP_BASEDATA` flag reaches end-chain's `process-outputs` on edge-routed scans. Part of the edge source-leakage redaction effort (CBP-44860).

## Flow

asset-service emits `EDGE_REDACTION_STRIP_BASEDATA` onto the execution plan → start-chain `configure` writes plan envs to outputs verbatim → workflow passes it to end-chain → end-chain forwards it into the container → `process-outputs` reads `os.Getenv` and strips BaseData from code-scanner findings.

This PR closes the two action-manifest gaps in that chain.

## Changes

- **`start-chain/action.yml`** — declare `EDGE_REDACTION_STRIP_BASEDATA` as an output (`steps.plan.outputs.EDGE_REDACTION_STRIP_BASEDATA`) so workflows can reference it.
- **`end-chain/action.yml`** — new `edge-redaction-strip-basedata` input, forwarded into the `process-outputs` container as the literal `EDGE_REDACTION_STRIP_BASEDATA` env var. (Composite-action step env doesn't auto-propagate into the inner container, so it must be an explicit input → env.)

## Related

- Consumer logic: calculi-corp/assets-plugin-chain-utils#180 (the `process-outputs` redaction)
- Producer: asset-service #1670 (emits the env), api-proto #134 (proto)
- Workflow wiring: compliance-workflows-preprod (separate PR) passes the input

## Notes

- Empty/absent on cloud scans → no redaction (routing is the on-switch).
- Merge/deploy this before the compliance-workflows PR, which references the new `edge-redaction-strip-basedata` input.

[CBP-46171]: https://cloudbees.atlassian.net/browse/CBP-46171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ