### PR TITLE
feat(CBP-46177): plumb EDGE_REDACTION_SWEEP_SARIF through chain actions

### DIFF
--- a/end-chain/action.yml
+++ b/end-chain/action.yml
@@ -7,6 +7,9 @@ inputs:
   edge-redaction-strip-basedata:
     description: "When 'true', strip BaseData (raw source) from code-scanner findings before posting. Set by the workflow from start-chain's output on edge-routed scans; empty on cloud scans."
     default: ""
+  edge-redaction-sweep-sarif:
+    description: "When 'true', strip source snippets from any .sarif file in the workspace before posting. Set by the workflow from start-chain's output on edge-routed scans; empty on cloud scans."
+    default: ""
 
 runs:
   using: composite
@@ -25,3 +28,4 @@ runs:
         # empty on cloud scans (no redaction). Passed in by the workflow from
         # start-chain's output.
         EDGE_REDACTION_STRIP_BASEDATA: ${{ inputs.edge-redaction-strip-basedata }}
+        EDGE_REDACTION_SWEEP_SARIF: ${{ inputs.edge-redaction-sweep-sarif }}

--- a/end-chain/action.yml
+++ b/end-chain/action.yml
@@ -24,8 +24,8 @@ runs:
         INPUT_CLOUDBEES_API_TOKEN: ${{ cloudbees.api.token }}
         INPUT_CLOUDBEES_API_URL: ${{ cloudbees.api.url }}
         INPUT_RUN_ID: ${{ cloudbees.run_id }}
-        # Edge redaction (CBP-46171). Read directly via os.Getenv in process-outputs;
-        # empty on cloud scans (no redaction). Passed in by the workflow from
-        # start-chain's output.
+        # Edge redaction (CBP-46171 basedata, CBP-46177 SARIF sweep). Read directly
+        # via os.Getenv in process-outputs; empty on cloud scans (no redaction).
+        # Passed in by the workflow from start-chain's outputs.
         EDGE_REDACTION_STRIP_BASEDATA: ${{ inputs.edge-redaction-strip-basedata }}
         EDGE_REDACTION_SWEEP_SARIF: ${{ inputs.edge-redaction-sweep-sarif }}

--- a/start-chain/action.yml
+++ b/start-chain/action.yml
@@ -153,6 +153,10 @@ outputs:
     value: ${{ steps.plan.outputs.EDGE_REDACTION_STRIP_BASEDATA }}
     description: "Strip BaseData (raw source) from code-scanner findings on edge"
 
+  EDGE_REDACTION_SWEEP_SARIF:
+    value: ${{ steps.plan.outputs.EDGE_REDACTION_SWEEP_SARIF }}
+    description: "Strip source snippets from .sarif files in the workspace on edge"
+
 runs:
   using: composite
   steps:
@@ -166,5 +170,5 @@ runs:
         INPUT_CLOUDBEES_API_TOKEN: ${{ cloudbees.api.token }}
         INPUT_CLOUDBEES_API_URL: ${{ cloudbees.api.url }}
         INPUT_RUN_ID: ${{ cloudbees.run_id }}
-        INPUT_INIT_OUTPUTS: 'wf_artifact_component_id,wf_artifact_token,ecr_role_arn,ecr_region_name,account_credentials,github-inventory,github-decorator,scc,bitbucket-inventory,bitbucket-decorator,gerrit-inventory,gerrit-decorator,gitlab-inventory,gitlab-decorator,gosec,njsscan,gitleaks,checkov,sonar-props,wfartifact-inventory,wfartifact-decorator,trivy,sonar,findsecbugs,syft,grype,blackduck,blackduck-props,coverity,coverity-props,perforce-klocwork-sast,perforce-klocwork-sast-props,snykcode,snykcode-props,snyk-iac,snyk-iac-props,snyksca,snyksca-props,checkmarxone-sast,checkmarxone-sast-props,ecr-inventory,ecr-metadata,jfrog-inventory,jfrog-metadata,jfrog_token,nexus-inventory,nexus-metadata,EDGE_REDACTION_STRIP_BASEDATA'
+        INPUT_INIT_OUTPUTS: 'wf_artifact_component_id,wf_artifact_token,ecr_role_arn,ecr_region_name,account_credentials,github-inventory,github-decorator,scc,bitbucket-inventory,bitbucket-decorator,gerrit-inventory,gerrit-decorator,gitlab-inventory,gitlab-decorator,gosec,njsscan,gitleaks,checkov,sonar-props,wfartifact-inventory,wfartifact-decorator,trivy,sonar,findsecbugs,syft,grype,blackduck,blackduck-props,coverity,coverity-props,perforce-klocwork-sast,perforce-klocwork-sast-props,snykcode,snykcode-props,snyk-iac,snyk-iac-props,snyksca,snyksca-props,checkmarxone-sast,checkmarxone-sast-props,ecr-inventory,ecr-metadata,jfrog-inventory,jfrog-metadata,jfrog_token,nexus-inventory,nexus-metadata,EDGE_REDACTION_STRIP_BASEDATA,EDGE_REDACTION_SWEEP_SARIF'
         INPUT_TIMEOUT: "300" # 5 minutes


### PR DESCRIPTION
[CBP-46177](https://cloudbees.atlassian.net/browse/CBP-46177)

## What
Action-manifest plumbing so the `EDGE_REDACTION_SWEEP_SARIF` flag reaches end-chain's `process-outputs` on edge-routed scans. Third edge source-leakage channel (after BaseData CBP-46171, logs CBP-46172/73).

## Changes
- **start-chain/action.yml** — declare `EDGE_REDACTION_SWEEP_SARIF` output + add to `INPUT_INIT_OUTPUTS`.
- **end-chain/action.yml** — new `edge-redaction-sweep-sarif` input, forwarded into the process-outputs container as `EDGE_REDACTION_SWEEP_SARIF` (composite-action step env doesn't auto-propagate into the inner container).

Exact mirror of the `EDGE_REDACTION_STRIP_BASEDATA` plumbing (#46).

## Dependency / order
- Producer: asset-service emits the env (after api-proto#167 → api regen).
- Workflow wiring: compliance-workflows-preprod passes the input (merge this **before** that PR, or the `with:` input is undefined on the pinned action).
- Consumer: calculi-corp/assets-plugin-chain-utils#188.

[CBP-46177]: https://cloudbees.atlassian.net/browse/CBP-46177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ