### PR TITLE
fix(CBP-46173): plumb EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS through start-chain

### DIFF
--- a/start-chain/action.yml
+++ b/start-chain/action.yml
@@ -157,6 +157,10 @@ outputs:
     value: ${{ steps.plan.outputs.EDGE_REDACTION_SWEEP_SARIF }}
     description: "Strip source snippets from .sarif files in the workspace on edge"
 
+  EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS:
+    value: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS }}
+    description: "Suppress code-scanner stdout/stderr logs on edge"
+
 runs:
   using: composite
   steps:
@@ -170,5 +174,5 @@ runs:
         INPUT_CLOUDBEES_API_TOKEN: ${{ cloudbees.api.token }}
         INPUT_CLOUDBEES_API_URL: ${{ cloudbees.api.url }}
         INPUT_RUN_ID: ${{ cloudbees.run_id }}
-        INPUT_INIT_OUTPUTS: 'wf_artifact_component_id,wf_artifact_token,ecr_role_arn,ecr_region_name,account_credentials,github-inventory,github-decorator,scc,bitbucket-inventory,bitbucket-decorator,gerrit-inventory,gerrit-decorator,gitlab-inventory,gitlab-decorator,gosec,njsscan,gitleaks,checkov,sonar-props,wfartifact-inventory,wfartifact-decorator,trivy,sonar,findsecbugs,syft,grype,blackduck,blackduck-props,coverity,coverity-props,perforce-klocwork-sast,perforce-klocwork-sast-props,snykcode,snykcode-props,snyk-iac,snyk-iac-props,snyksca,snyksca-props,checkmarxone-sast,checkmarxone-sast-props,ecr-inventory,ecr-metadata,jfrog-inventory,jfrog-metadata,jfrog_token,nexus-inventory,nexus-metadata,EDGE_REDACTION_STRIP_BASEDATA,EDGE_REDACTION_SWEEP_SARIF'
+        INPUT_INIT_OUTPUTS: 'wf_artifact_component_id,wf_artifact_token,ecr_role_arn,ecr_region_name,account_credentials,github-inventory,github-decorator,scc,bitbucket-inventory,bitbucket-decorator,gerrit-inventory,gerrit-decorator,gitlab-inventory,gitlab-decorator,gosec,njsscan,gitleaks,checkov,sonar-props,wfartifact-inventory,wfartifact-decorator,trivy,sonar,findsecbugs,syft,grype,blackduck,blackduck-props,coverity,coverity-props,perforce-klocwork-sast,perforce-klocwork-sast-props,snykcode,snykcode-props,snyk-iac,snyk-iac-props,snyksca,snyksca-props,checkmarxone-sast,checkmarxone-sast-props,ecr-inventory,ecr-metadata,jfrog-inventory,jfrog-metadata,jfrog_token,nexus-inventory,nexus-metadata,EDGE_REDACTION_STRIP_BASEDATA,EDGE_REDACTION_SWEEP_SARIF,EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'
         INPUT_TIMEOUT: "300" # 5 minutes


### PR DESCRIPTION
## What
Add `EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS` to start-chain's `outputs:` block and `INPUT_INIT_OUTPUTS` allowlist, mirroring its two sibling redaction flags (`STRIP_BASEDATA`, `SWEEP_SARIF`).

## Why
The suppress-logs flag was emitted by asset-service and consumed by `code_scan_edge.yaml` (`CLOUDBEES_SUPPRESS_LOGS`), and the runtime fix (dsl-engine-cli #826) was deployed — but start-chain never surfaced the variable as a plan output. With the key absent, `steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS']` resolved empty, the workflow's `|| 'false'` coalesce forced `CLOUDBEES_SUPPRESS_LOGS=false`, and code-scanner logs leaked on every edge scan (confirmed on EdgeRunnerTest run #10: gitleaks step output fully visible).

This was the one missing link in the chain — producer, workflow, and runtime were all correct.