### PR TITLE
feat(CBP-46178): pass suppress-code-scanner-logs input to end-chain

### DIFF
--- a/end-chain/action.yml
+++ b/end-chain/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: "When 'true', strip source snippets from any .sarif file in the workspace before posting. Set by the workflow from start-chain's output on edge-routed scans; empty on cloud scans."
     default: ""
   edge-redaction-suppress-code-scanner-logs:
-    description: "When 'true', the runtime suppressed code-scanner logs on this edge scan; end-chain prints an on-premise-retention notice in the job log. Set by the workflow from start-chain's output on edge-routed scans; empty on cloud scans."
+    description: "When 'true', the runtime suppressed code-scanner logs on this edge scan; end-chain prints an on-premise retention notice in the job log. Set by the workflow from start-chain's output on edge-routed scans; empty on cloud scans."
     default: ""
 
 runs:

--- a/end-chain/action.yml
+++ b/end-chain/action.yml
@@ -10,6 +10,9 @@ inputs:
   edge-redaction-sweep-sarif:
     description: "When 'true', strip source snippets from any .sarif file in the workspace before posting. Set by the workflow from start-chain's output on edge-routed scans; empty on cloud scans."
     default: ""
+  edge-redaction-suppress-code-scanner-logs:
+    description: "When 'true', the runtime suppressed code-scanner logs on this edge scan; end-chain prints an on-premise-retention notice in the job log. Set by the workflow from start-chain's output on edge-routed scans; empty on cloud scans."
+    default: ""
 
 runs:
   using: composite
@@ -24,8 +27,9 @@ runs:
         INPUT_CLOUDBEES_API_TOKEN: ${{ cloudbees.api.token }}
         INPUT_CLOUDBEES_API_URL: ${{ cloudbees.api.url }}
         INPUT_RUN_ID: ${{ cloudbees.run_id }}
-        # Edge redaction (CBP-46171 basedata, CBP-46177 SARIF sweep). Read directly
-        # via os.Getenv in process-outputs; empty on cloud scans (no redaction).
-        # Passed in by the workflow from start-chain's outputs.
+        # Edge redaction (CBP-46171 basedata, CBP-46177 SARIF sweep, CBP-46178 log
+        # notice). Read directly via os.Getenv in process-outputs; empty on cloud
+        # scans (no redaction). Passed in by the workflow from start-chain's outputs.
         EDGE_REDACTION_STRIP_BASEDATA: ${{ inputs.edge-redaction-strip-basedata }}
         EDGE_REDACTION_SWEEP_SARIF: ${{ inputs.edge-redaction-sweep-sarif }}
+        EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS: ${{ inputs.edge-redaction-suppress-code-scanner-logs }}


### PR DESCRIPTION
## What
Adds an `edge-redaction-suppress-code-scanner-logs` input to the end-chain action and maps it to `EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS` on the process-outputs container.

## Why
Lets end-chain print the on-premise log-retention notice (CBP-46178) when the runtime suppressed code-scanner logs on an edge scan. Mirrors the existing `edge-redaction-strip-basedata` / `edge-redaction-sweep-sarif` inputs.

## Companion PRs
- assets-plugin-chain-utils#195 (prints the notice)
- compliance-workflows-preprod (workflow feeds the input from the plan output)

Note: needs the floating `v1` tag moved after merge (same as prior edge-redaction inputs), since `code_scan_edge.yaml` pins `end-chain@v1`.